### PR TITLE
Modified placeholder format in response mappings "${xyz}"

### DIFF
--- a/src/main/java/in/das/app/wiremock/extensions/ResponseFillUsingParamTransformer.java
+++ b/src/main/java/in/das/app/wiremock/extensions/ResponseFillUsingParamTransformer.java
@@ -1,18 +1,18 @@
 package in.das.app.wiremock.extensions;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.extension.ResponseTransformerV2;
-import com.github.tomakehurst.wiremock.http.Response;
-import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import in.das.app.wiremock.utils.TransformerUtils;
-import lombok.extern.slf4j.Slf4j;
+        import com.fasterxml.jackson.core.JsonProcessingException;
+        import com.fasterxml.jackson.databind.JsonNode;
+        import com.fasterxml.jackson.databind.ObjectMapper;
+        import com.github.tomakehurst.wiremock.extension.ResponseTransformerV2;
+        import com.github.tomakehurst.wiremock.http.Response;
+        import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+        import in.das.app.wiremock.utils.TransformerUtils;
+        import lombok.extern.slf4j.Slf4j;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+        import java.io.IOException;
+        import java.util.HashMap;
+        import java.util.List;
+        import java.util.Map;
 
 @Slf4j
 public class ResponseFillUsingParamTransformer implements ResponseTransformerV2 {
@@ -21,7 +21,10 @@ public class ResponseFillUsingParamTransformer implements ResponseTransformerV2 
 
     @Override
     public Response transform(Response response, ServeEvent serveEvent) {
-        Map<String, Object> map = new HashMap<>(serveEvent.getTransformerParameters());
+        Map<String, Object> map = new HashMap<>();
+        serveEvent.getTransformerParameters().forEach((param,obj) -> {
+            map.put("${" + param + "}", obj);
+        });
         JsonNode responseJson;
         try {
             responseJson = mapper.readValue(response.getBody(), JsonNode.class);
@@ -57,9 +60,9 @@ public class ResponseFillUsingParamTransformer implements ResponseTransformerV2 
         }
         for(String node : nodesToReplace){
             if(paramMap.get(node) instanceof String) {
-                responseJson = responseJson.replaceAll("\\$" + node.substring(1), (String) paramMap.get(node));
+                responseJson = responseJson.replaceAll("\\$\\{" + node.substring(2, node.length()-1) + "}", (String) paramMap.get(node));
             } else {
-                log.error("complex (not string) value found for parameter: \"{}\", substitution skipped", node);
+                log.error("complex (not string) value found for parameter: \"{}\", substitution skipped", node.substring(2, node.length()-1));
             }
         }
         return responseJson;

--- a/src/main/java/in/das/app/wiremock/extensions/ResponseFillUsingRequestTransformer.java
+++ b/src/main/java/in/das/app/wiremock/extensions/ResponseFillUsingRequestTransformer.java
@@ -67,11 +67,12 @@ public class ResponseFillUsingRequestTransformer implements ResponseTransformerV
         }
 
         for(String node : nodesToReplace){
-            if(requestNode.has(node.substring(1))){
-                String nodeValue = requestNode.get(node.substring(1)).textValue();
-                responseJson = responseJson.replaceAll("\\$" + node.substring(1), nodeValue);
+            node = node.substring(2, node.length()-1);
+            if(requestNode.has(node)){
+                String nodeValue = requestNode.get(node).textValue();
+                responseJson = responseJson.replaceAll("\\$\\{" + node + "}", nodeValue);
             } else {
-                log.error("No substitution found for \"{}\" in request", node);
+                log.error("No substitution found for \"${{}}\" in request", node);
             }
         }
         return responseJson;

--- a/src/main/java/in/das/app/wiremock/utils/TransformerUtils.java
+++ b/src/main/java/in/das/app/wiremock/utils/TransformerUtils.java
@@ -15,7 +15,7 @@ public interface TransformerUtils {
 
         if(node.isObject()){
             node.fields().forEachRemaining(entry -> {
-                if(entry.getValue().isTextual() && entry.getValue().textValue().startsWith("$")){
+                if(entry.getValue().isTextual() && entry.getValue().textValue().startsWith("${") && entry.getValue().textValue().endsWith("}")){
                     arr.add(entry.getValue().textValue());
                 }
                 else if(entry.getValue().isObject() || entry.getValue().isArray()){

--- a/src/main/resources/BOOT-INF/wiremock/__files/app1/responses/app1_POST_header_test3_response.json
+++ b/src/main/resources/BOOT-INF/wiremock/__files/app1/responses/app1_POST_header_test3_response.json
@@ -1,3 +1,5 @@
 {
-  "name" : "$name"
+  "error" : "${error}",
+  "status" : "${status}",
+  "errorMessage" : "${errorMessage}"
 }

--- a/src/main/resources/BOOT-INF/wiremock/mappings/app1/app1_POST_header_test3_mapping.json
+++ b/src/main/resources/BOOT-INF/wiremock/mappings/app1/app1_POST_header_test3_mapping.json
@@ -18,9 +18,13 @@
       "X-APP-TRX-ID" : "trx-100",
       "response-from" : "mock-server"
     },
-    "transformers" : ["response-fill-using-param-transformer"],
+    "transformers" : [
+      "response-fill-using-param-transformer"
+    ],
     "transformerParameters" : {
-      "$name" : "abc"
+      "error" : "Bad Request",
+      "status" : "400",
+      "errorMessage" : "some error message"
     }
   }
 }


### PR DESCRIPTION
Modified placeholder format in response mappings to now `"${xyz}"`.
Earlier the placeholder format was like `$xzy`. This created an issue while substituting similar placeholders, ex: `$error` & `$errorMessage`. 